### PR TITLE
Fix dependency injection for knp snappy pdf

### DIFF
--- a/Pdf/PdfManager.php
+++ b/Pdf/PdfManager.php
@@ -10,7 +10,7 @@
 
 namespace Massive\Bundle\PdfBundle\Pdf;
 
-use Knp\Bundle\SnappyBundle\Snappy\LoggableGenerator as PdfGenerator;
+use Knp\Snappy\Pdf as PdfGenerator;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 
 /**

--- a/Pdf/PdfManager.php
+++ b/Pdf/PdfManager.php
@@ -10,7 +10,7 @@
 
 namespace Massive\Bundle\PdfBundle\Pdf;
 
-use Knp\Snappy\Pdf as PdfGenerator;
+use Knp\Snappy\GeneratorInterface as PdfGenerator;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 
 /**


### PR DESCRIPTION
Fixed a problem with dependency injection. The Parameter called in `Resources/config/services.xml` is of Type `Knp\Snappy\Pdf` and not of type `Knp\Bundle\SnappyBundle\Snappy\LoggableGenerator` as in current Develop. This will throw an error when trying to use the pdf generator.